### PR TITLE
Add color-theme-aware Auto themes for fish 4.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ Download the variant of your choice from `themes` and place it inside `~/.config
 1. Add `fish_config theme choose "Rosé Pine {Dawn, Moon}"` to `~/.config/fish/config.fish`
 2. Reload fish via `exec fish`
 
+### Color-theme-aware themes (fish 4.3+)
+
+Fish 4.3 added support for themes that automatically switch between dark and light variants based on your terminal's background color. Use the "Auto" themes to enable this:
+
+- **Rosé Pine Auto** - Switches between Rosé Pine (dark) and Rosé Pine Dawn (light)
+- **Rosé Pine Moon Auto** - Switches between Rosé Pine Moon (dark) and Rosé Pine Dawn (light)
+
+```fish
+fish_config theme choose "Rosé Pine Auto"
+# or
+fish_config theme choose "Rosé Pine Moon Auto"
+```
+
 ## Gallery
 
 **Rosé Pine**

--- a/build.sh
+++ b/build.sh
@@ -4,3 +4,23 @@ npx @rose-pine/build@latest -f hex-ns -t ./source.theme -o ./themes
 mv ./themes/rose-pine.theme "./themes/Rosé Pine.theme"
 mv ./themes/rose-pine-dawn.theme "./themes/Rosé Pine Dawn.theme"
 mv ./themes/rose-pine-moon.theme "./themes/Rosé Pine Moon.theme"
+
+# Create color-theme-aware "Auto" themes for fish 4.3+
+# These automatically switch between dark and light variants based on terminal background
+
+create_auto_theme() {
+    dark_theme="$1"
+    light_theme="$2"
+    output="$3"
+
+    {
+        echo "[dark]"
+        cat "$dark_theme"
+        echo ""
+        echo "[light]"
+        cat "$light_theme"
+    } > "$output"
+}
+
+create_auto_theme "./themes/Rosé Pine.theme" "./themes/Rosé Pine Dawn.theme" "./themes/Rosé Pine Auto.theme"
+create_auto_theme "./themes/Rosé Pine Moon.theme" "./themes/Rosé Pine Dawn.theme" "./themes/Rosé Pine Moon Auto.theme"

--- a/build.sh
+++ b/build.sh
@@ -9,17 +9,17 @@ mv ./themes/rose-pine-moon.theme "./themes/Rosé Pine Moon.theme"
 # These automatically switch between dark and light variants based on terminal background
 
 create_auto_theme() {
-    dark_theme="$1"
-    light_theme="$2"
-    output="$3"
+	dark_theme="$1"
+	light_theme="$2"
+	output="$3"
 
-    {
-        echo "[dark]"
-        cat "$dark_theme"
-        echo ""
-        echo "[light]"
-        cat "$light_theme"
-    } > "$output"
+	{
+		echo "[dark]"
+		cat "$dark_theme"
+		echo ""
+		echo "[light]"
+		cat "$light_theme"
+	} >"$output"
 }
 
 create_auto_theme "./themes/Rosé Pine.theme" "./themes/Rosé Pine Dawn.theme" "./themes/Rosé Pine Auto.theme"

--- a/themes/Rosé Pine Auto.theme
+++ b/themes/Rosé Pine Auto.theme
@@ -1,0 +1,105 @@
+[dark]
+# syntax highlighting variables
+# https://fishshell.com/docs/current/interactive.html#syntax-highlighting-variables
+fish_color_normal e0def4
+fish_color_command c4a7e7
+fish_color_keyword 9ccfd8
+fish_color_quote f6c177
+fish_color_redirection 31748f
+fish_color_end 908caa
+fish_color_error eb6f92
+fish_color_param ebbcba
+fish_color_comment 908caa
+# fish_color_match --background=brblue
+fish_color_selection --reverse
+# fish_color_history_current --bold
+fish_color_operator e0def4
+fish_color_escape 31748f
+fish_color_autosuggestion 908caa
+fish_color_cwd ebbcba
+# fish_color_cwd_root red
+fish_color_user f6c177
+fish_color_host 9ccfd8
+fish_color_host_remote c4a7e7
+fish_color_cancel e0def4
+fish_color_search_match --background=191724
+fish_color_valid_path
+
+# pager color variables
+# https://fishshell.com/docs/current/interactive.html#pager-color-variables
+fish_pager_color_progress ebbcba
+fish_pager_color_background --background=1f1d2e
+fish_pager_color_prefix 9ccfd8
+fish_pager_color_completion 908caa
+fish_pager_color_description 908caa
+fish_pager_color_secondary_background
+fish_pager_color_secondary_prefix
+fish_pager_color_secondary_completion
+fish_pager_color_secondary_description
+fish_pager_color_selected_background --background=26233a
+fish_pager_color_selected_prefix 9ccfd8
+fish_pager_color_selected_completion e0def4
+fish_pager_color_selected_description e0def4
+
+# custom color variables
+fish_color_subtle 908caa
+fish_color_text e0def4
+fish_color_love eb6f92
+fish_color_gold f6c177
+fish_color_rose ebbcba
+fish_color_pine 31748f
+fish_color_foam 9ccfd8
+fish_color_iris c4a7e7
+
+[light]
+# syntax highlighting variables
+# https://fishshell.com/docs/current/interactive.html#syntax-highlighting-variables
+fish_color_normal 575279
+fish_color_command 907aa9
+fish_color_keyword 56949f
+fish_color_quote ea9d34
+fish_color_redirection 286983
+fish_color_end 797593
+fish_color_error b4637a
+fish_color_param d7827e
+fish_color_comment 797593
+# fish_color_match --background=brblue
+fish_color_selection --reverse
+# fish_color_history_current --bold
+fish_color_operator 575279
+fish_color_escape 286983
+fish_color_autosuggestion 797593
+fish_color_cwd d7827e
+# fish_color_cwd_root red
+fish_color_user ea9d34
+fish_color_host 56949f
+fish_color_host_remote 907aa9
+fish_color_cancel 575279
+fish_color_search_match --background=faf4ed
+fish_color_valid_path
+
+# pager color variables
+# https://fishshell.com/docs/current/interactive.html#pager-color-variables
+fish_pager_color_progress d7827e
+fish_pager_color_background --background=fffaf3
+fish_pager_color_prefix 56949f
+fish_pager_color_completion 797593
+fish_pager_color_description 797593
+fish_pager_color_secondary_background
+fish_pager_color_secondary_prefix
+fish_pager_color_secondary_completion
+fish_pager_color_secondary_description
+fish_pager_color_selected_background --background=f2e9e1
+fish_pager_color_selected_prefix 56949f
+fish_pager_color_selected_completion 575279
+fish_pager_color_selected_description 575279
+
+# custom color variables
+fish_color_subtle 797593
+fish_color_text 575279
+fish_color_love b4637a
+fish_color_gold ea9d34
+fish_color_rose d7827e
+fish_color_pine 286983
+fish_color_foam 56949f
+fish_color_iris 907aa9

--- a/themes/Rosé Pine Moon Auto.theme
+++ b/themes/Rosé Pine Moon Auto.theme
@@ -1,0 +1,105 @@
+[dark]
+# syntax highlighting variables
+# https://fishshell.com/docs/current/interactive.html#syntax-highlighting-variables
+fish_color_normal e0def4
+fish_color_command c4a7e7
+fish_color_keyword 9ccfd8
+fish_color_quote f6c177
+fish_color_redirection 3e8fb0
+fish_color_end 908caa
+fish_color_error eb6f92
+fish_color_param ea9a97
+fish_color_comment 908caa
+# fish_color_match --background=brblue
+fish_color_selection --reverse
+# fish_color_history_current --bold
+fish_color_operator e0def4
+fish_color_escape 3e8fb0
+fish_color_autosuggestion 908caa
+fish_color_cwd ea9a97
+# fish_color_cwd_root red
+fish_color_user f6c177
+fish_color_host 9ccfd8
+fish_color_host_remote c4a7e7
+fish_color_cancel e0def4
+fish_color_search_match --background=232136
+fish_color_valid_path
+
+# pager color variables
+# https://fishshell.com/docs/current/interactive.html#pager-color-variables
+fish_pager_color_progress ea9a97
+fish_pager_color_background --background=2a273f
+fish_pager_color_prefix 9ccfd8
+fish_pager_color_completion 908caa
+fish_pager_color_description 908caa
+fish_pager_color_secondary_background
+fish_pager_color_secondary_prefix
+fish_pager_color_secondary_completion
+fish_pager_color_secondary_description
+fish_pager_color_selected_background --background=393552
+fish_pager_color_selected_prefix 9ccfd8
+fish_pager_color_selected_completion e0def4
+fish_pager_color_selected_description e0def4
+
+# custom color variables
+fish_color_subtle 908caa
+fish_color_text e0def4
+fish_color_love eb6f92
+fish_color_gold f6c177
+fish_color_rose ea9a97
+fish_color_pine 3e8fb0
+fish_color_foam 9ccfd8
+fish_color_iris c4a7e7
+
+[light]
+# syntax highlighting variables
+# https://fishshell.com/docs/current/interactive.html#syntax-highlighting-variables
+fish_color_normal 575279
+fish_color_command 907aa9
+fish_color_keyword 56949f
+fish_color_quote ea9d34
+fish_color_redirection 286983
+fish_color_end 797593
+fish_color_error b4637a
+fish_color_param d7827e
+fish_color_comment 797593
+# fish_color_match --background=brblue
+fish_color_selection --reverse
+# fish_color_history_current --bold
+fish_color_operator 575279
+fish_color_escape 286983
+fish_color_autosuggestion 797593
+fish_color_cwd d7827e
+# fish_color_cwd_root red
+fish_color_user ea9d34
+fish_color_host 56949f
+fish_color_host_remote 907aa9
+fish_color_cancel 575279
+fish_color_search_match --background=faf4ed
+fish_color_valid_path
+
+# pager color variables
+# https://fishshell.com/docs/current/interactive.html#pager-color-variables
+fish_pager_color_progress d7827e
+fish_pager_color_background --background=fffaf3
+fish_pager_color_prefix 56949f
+fish_pager_color_completion 797593
+fish_pager_color_description 797593
+fish_pager_color_secondary_background
+fish_pager_color_secondary_prefix
+fish_pager_color_secondary_completion
+fish_pager_color_secondary_description
+fish_pager_color_selected_background --background=f2e9e1
+fish_pager_color_selected_prefix 56949f
+fish_pager_color_selected_completion 575279
+fish_pager_color_selected_description 575279
+
+# custom color variables
+fish_color_subtle 797593
+fish_color_text 575279
+fish_color_love b4637a
+fish_color_gold ea9d34
+fish_color_rose d7827e
+fish_color_pine 286983
+fish_color_foam 56949f
+fish_color_iris 907aa9


### PR DESCRIPTION
## Summary

- Adds two new "Auto" themes that automatically switch between dark and light variants based on terminal background color (fish 4.3+ feature)
- **Rosé Pine Auto**: Switches between Rosé Pine (dark) and Rosé Pine Dawn (light)
- **Rosé Pine Moon Auto**: Switches between Rosé Pine Moon (dark) and Rosé Pine Dawn (light)
- Updates build script to generate the Auto themes by combining existing theme files
- Documents the new themes in README

Closes #5

## Test plan

- [x] Tested "Rosé Pine Auto" theme with fish 4.3+ and verified automatic switching works

🤖 Generated with [Claude Code](https://claude.com/claude-code)