### PR TITLE
Fix non-zero exit status from conf.d scripts

### DIFF
--- a/conf.d/rose-pine-pure.fish
+++ b/conf.d/rose-pine-pure.fish
@@ -4,45 +4,45 @@
 # Automatically applies Rosé Pine colors to pure prompt
 # when a Rosé Pine fish theme is active.
 
-type -q _pure_prompt; or return
+type -q _pure_prompt; or return 0
 
 function _rose_pine_pure_primary --on-variable fish_color_rose
-    set -q fish_color_rose[1]; or return
+    set -q fish_color_rose[1]; or return 0
     set -g pure_color_primary $fish_color_rose[1]
 end
 
 function _rose_pine_pure_info --on-variable fish_color_foam
-    set -q fish_color_foam[1]; or return
+    set -q fish_color_foam[1]; or return 0
     set -g pure_color_info $fish_color_foam[1]
 end
 
 function _rose_pine_pure_mute --on-variable fish_color_subtle
-    set -q fish_color_subtle[1]; or return
+    set -q fish_color_subtle[1]; or return 0
     set -g pure_color_mute $fish_color_subtle[1]
 end
 
 function _rose_pine_pure_success --on-variable fish_color_iris
-    set -q fish_color_iris[1]; or return
+    set -q fish_color_iris[1]; or return 0
     set -g pure_color_success $fish_color_iris[1]
 end
 
 function _rose_pine_pure_danger --on-variable fish_color_love
-    set -q fish_color_love[1]; or return
+    set -q fish_color_love[1]; or return 0
     set -g pure_color_danger $fish_color_love[1]
 end
 
 function _rose_pine_pure_warning --on-variable fish_color_gold
-    set -q fish_color_gold[1]; or return
+    set -q fish_color_gold[1]; or return 0
     set -g pure_color_warning $fish_color_gold[1]
 end
 
 function _rose_pine_pure_light --on-variable fish_color_text
-    set -q fish_color_text[1]; or return
+    set -q fish_color_text[1]; or return 0
     set -g pure_color_light $fish_color_text[1]
 end
 
 function _rose_pine_pure_dark --on-variable fish_color_pine
-    set -q fish_color_pine[1]; or return
+    set -q fish_color_pine[1]; or return 0
     set -g pure_color_dark $fish_color_pine[1]
 end
 

--- a/conf.d/rose-pine-tide.fish
+++ b/conf.d/rose-pine-tide.fish
@@ -4,10 +4,10 @@
 # Automatically applies Rosé Pine colors to Tide prompt
 # when a Rosé Pine fish theme is active.
 
-type -q tide; or return
+type -q tide; or return 0
 
 function _rose_pine_tide_base --on-variable fish_color_base
-    set -q fish_color_base[1]; or return
+    set -q fish_color_base[1]; or return 0
     set -l base $fish_color_base[1]
 
     # All segment foreground colors use base
@@ -62,7 +62,7 @@ function _rose_pine_tide_base --on-variable fish_color_base
 end
 
 function _rose_pine_tide_iris --on-variable fish_color_iris
-    set -q fish_color_iris[1]; or return
+    set -q fish_color_iris[1]; or return 0
     set -l iris $fish_color_iris[1]
     set -gx tide_os_bg_color $iris
     set -gx tide_cmd_duration_bg_color $iris
@@ -72,7 +72,7 @@ function _rose_pine_tide_iris --on-variable fish_color_iris
 end
 
 function _rose_pine_tide_foam --on-variable fish_color_foam
-    set -q fish_color_foam[1]; or return
+    set -q fish_color_foam[1]; or return 0
     set -l foam $fish_color_foam[1]
     set -gx tide_pwd_bg_color $foam
     set -gx tide_git_bg_color $foam
@@ -83,7 +83,7 @@ function _rose_pine_tide_foam --on-variable fish_color_foam
 end
 
 function _rose_pine_tide_love --on-variable fish_color_love
-    set -q fish_color_love[1]; or return
+    set -q fish_color_love[1]; or return 0
     set -l love $fish_color_love[1]
     set -gx tide_git_bg_color_urgent $love
     set -gx tide_character_color_failure $love
@@ -93,7 +93,7 @@ function _rose_pine_tide_love --on-variable fish_color_love
 end
 
 function _rose_pine_tide_gold --on-variable fish_color_gold
-    set -q fish_color_gold[1]; or return
+    set -q fish_color_gold[1]; or return 0
     set -l gold $fish_color_gold[1]
     set -gx tide_git_bg_color_unstable $gold
     set -gx tide_jobs_bg_color $gold
@@ -101,7 +101,7 @@ function _rose_pine_tide_gold --on-variable fish_color_gold
 end
 
 function _rose_pine_tide_pine --on-variable fish_color_pine
-    set -q fish_color_pine[1]; or return
+    set -q fish_color_pine[1]; or return 0
     set -l pine $fish_color_pine[1]
     set -gx tide_character_color $pine
     set -gx tide_node_bg_color $pine
@@ -127,12 +127,12 @@ function _rose_pine_tide_pine --on-variable fish_color_pine
 end
 
 function _rose_pine_tide_rose --on-variable fish_color_rose
-    set -q fish_color_rose[1]; or return
+    set -q fish_color_rose[1]; or return 0
     set -gx tide_vi_mode_bg_color_replace $fish_color_rose[1]
 end
 
 function _rose_pine_tide_subtle --on-variable fish_color_subtle
-    set -q fish_color_subtle[1]; or return
+    set -q fish_color_subtle[1]; or return 0
     set -l subtle $fish_color_subtle[1]
     set -gx tide_prompt_color_frame_and_connection $subtle
     set -gx tide_prompt_color_separator_same_color $subtle


### PR DESCRIPTION
## Summary
- `or return` without an explicit status propagates the non-zero exit code from failed `set -q` / `type -q` checks
- This causes `fisher install` and `fisher update` to exit with status 1 when the prompt (pure/tide) isn't installed or when theme color variables aren't set yet
- Changed all `or return` to `or return 0` in both conf.d scripts

## Test plan
- [x] `fisher install rose-pine/fish` returns exit status 0 without pure or tide installed
- [x] `fisher update` returns exit status 0 with rose-pine/fish in fish_plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)